### PR TITLE
Adds owner appointment deletion

### DIFF
--- a/app/main/models/appointment.rb
+++ b/app/main/models/appointment.rb
@@ -5,6 +5,8 @@ class Appointment < Volt::Model
   field :start_time, String
   field :end_time, String
 
+  permissions(:delete) { deny unless owner? }
+
   def useful_start_time
     start_time.gsub(":", "").to_i
   end

--- a/app/main/views/main/index.html
+++ b/app/main/views/main/index.html
@@ -41,14 +41,21 @@
                 <span>{{ appointment._specialty }}</span>
                 </td>
                 <td>
-                <span>{{ appointment._start_time }}</span>
+                <span>{{ appointment.start_time }}</span>
                 </td>
                 <td>
-                <span>{{ appointment._end_time }}</span>
+                <span>{{ appointment.end_time }}</span>
                 </td>
                 <td>
                   <form class="form-inline center" e-submit="update_attendee">
                   <input type="text" class="form-control" placeholder="Enter an Attendee" value="{{ appointment._attendee }}">
+                </td>
+                <td>
+                  {{ if appointment.can_delete? }}
+                    <span class="pull-right">
+                      <button e-click="appointment.destroy" class="btn btn-xs btn-danger glyphicon glyphicon-trash"></button>
+                    </span>
+                  {{ end }}
                 </td>
               </tr>
             {{ end }}


### PR DESCRIPTION
## Minor bug

Right now, there's a little bug where the user has to reload the page between creating and deleting an appointment. Other than that, it works great.
### What Changed?
- Adds a little red trash can for a user to delete his own appointment.

This is what it looks like:
![screen shot 2015-07-16 at 2 43 27 pm](https://cloud.githubusercontent.com/assets/1161474/8732931/a763ed1c-2bce-11e5-894b-4e2db0861b07.png)
